### PR TITLE
Jackson databind upgrade to 2.9.9

### DIFF
--- a/base-plugin/pom.xml
+++ b/base-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.9.0</version>
+		<version>2.9.1</version>
 	</parent>
 	<artifactId>base-plugin</artifactId>
 

--- a/bitbucket-plugin/pom.xml
+++ b/bitbucket-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
     </parent>
     <artifactId>bitbucket-plugin</artifactId>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.9.9</version>
+		    <version>2.9.9.3</version>
 		</dependency>
 		
 		<dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.9.0</version>
+		<version>2.9.1</version>
 	</parent>
 
 	<artifactId>common</artifactId>
@@ -54,7 +54,7 @@
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.9.8</version>
+		    <version>2.9.9</version>
 		</dependency>
 		
 		<dependency>

--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
     </parent>
     <artifactId>confluence-plugin</artifactId>
     <organization>

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>jira-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.cloudflare.access.atlassian</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.9.0</version>
+	<version>2.9.1</version>
 	<packaging>pom</packaging>
 
 	<name>Cloudflare Access for Atlassian</name>


### PR DESCRIPTION
- Upgraded jackson databind library to 2.9.9.3
- Release version already bumped to publish release after merge (drafted release)