### PR TITLE
#41 enforce atlassian flow + Jackson Databind upgrades

### DIFF
--- a/base-plugin/pom.xml
+++ b/base-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.9.0</version>
+		<version>2.9.1</version>
 	</parent>
 	<artifactId>base-plugin</artifactId>
 

--- a/base-plugin/pom.xml
+++ b/base-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.9.1</version>
+		<version>2.10.0</version>
 	</parent>
 	<artifactId>base-plugin</artifactId>
 

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/auth/CloudflareAccessService.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/auth/CloudflareAccessService.java
@@ -103,6 +103,12 @@ public class CloudflareAccessService {
 				return;
 			}
 
+			if(requiresAtlassianAuthentication(token)) {
+				log.debug("User required to do atlassian authentication...");
+				chain.doFilter(request, response);
+				return;
+			}
+
 			User user = userService.getUser(token.getUserEmail());
 			successHandler.handle(request, response, chain, user);
 
@@ -187,6 +193,10 @@ public class CloudflareAccessService {
 			return true;
 		}
 		return false;
+	}
+
+	private boolean requiresAtlassianAuthentication(CloudflareToken token) {
+		return configurationService.emailDomainRequiresAtlassianAuthentication(token.getUserEmail());
 	}
 
 }

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationService.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationService.java
@@ -11,4 +11,6 @@ public interface ConfigurationService {
 	Optional<ConfigurationVariables> loadConfigurationVariables();
 
 	Optional<PluginConfiguration> getPluginConfiguration();
+
+	boolean emailDomainRequiresAtlassianAuthentication(String email);
 }

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationServlet.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationServlet.java
@@ -133,8 +133,9 @@ public class ConfigurationServlet extends HttpServlet{
 	private ConfigurationVariables loadFromRequest(HttpServletRequest request) {
 		String tokenAudience = request.getParameter("tokenAudience");
 	    String authDomain = request.getParameter("authDomain");
+	    String allowedEmailDomain = request.getParameter("allowedEmailDomain");
 
-		return new ConfigurationVariables(tokenAudience, authDomain);
+		return new ConfigurationVariables(tokenAudience, authDomain, allowedEmailDomain);
 	}
 
 	private Map<String, Object> createContext(){

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariables.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariables.java
@@ -14,6 +14,7 @@ public class ConfigurationVariables {
 	public static final String VALID_FLAG_SETTINGS_KEY = SETTINGS_PREFIX + "is.valid";
 	public static final String TOKEN_AUDIENCE_SETTINGS_KEY = SETTINGS_PREFIX + "tokenAudience";
 	public static final String AUTH_DOMAIN_SETTINGS_KEY = SETTINGS_PREFIX + "authDomain";
+	public static final String ALLOWED_EMAIL_DOMAIN_SETTINGS_KEY = SETTINGS_PREFIX + "authDomain";
 
 	@NotNull(message="cfaccess.config.tokenAudience.should.not.be.empty")
 	@Size(min=1, message="cfaccess.config.tokenAudience.should.not.be.empty")
@@ -24,16 +25,21 @@ public class ConfigurationVariables {
 	@Domain(message="cfaccess.config.authDomain.should.be.valid")
 	private String authDomain;
 
+	@Domain(message="cfaccess.config.allowedEmailDomain.should.be.valid")
+	private String allowedEmailDomain;
+
 	public ConfigurationVariables(ConfigurationVariablesActiveObject activeObject) {
 		super();
 		this.tokenAudience = activeObject.getTokenAudience();
 		this.authDomain = activeObject.getAuthDomain();
+		this.allowedEmailDomain = activeObject.getAllowedEmailDomain();
 	}
 
-	public ConfigurationVariables(String tokenAudience, String authDomain) {
+	public ConfigurationVariables(String tokenAudience, String authDomain, String allowedEmailDomain) {
 		super();
 		this.tokenAudience = tokenAudience;
 		this.authDomain = authDomain;
+		this.allowedEmailDomain = allowedEmailDomain;
 	}
 
 	public String getTokenAudience() {
@@ -42,6 +48,10 @@ public class ConfigurationVariables {
 
 	public String getAuthDomain() {
 		return authDomain;
+	}
+
+	public String getAllowedEmailDomain() {
+		return allowedEmailDomain;
 	}
 
 	@Override

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariables.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariables.java
@@ -7,6 +7,8 @@ import org.apache.bval.extras.constraints.net.Domain;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import com.cloudflare.access.atlassian.base.config.validation.NullableDomain;
+
 public class ConfigurationVariables {
 
 	private static final String SETTINGS_PREFIX = ConfigurationVariables.class.getName() + ".";
@@ -25,7 +27,7 @@ public class ConfigurationVariables {
 	@Domain(message="cfaccess.config.authDomain.should.be.valid")
 	private String authDomain;
 
-	@Domain(message="cfaccess.config.allowedEmailDomain.should.be.valid")
+	@NullableDomain(message="cfaccess.config.allowedEmailDomain.should.be.valid")
 	private String allowedEmailDomain;
 
 	public ConfigurationVariables(ConfigurationVariablesActiveObject activeObject) {
@@ -58,4 +60,5 @@ public class ConfigurationVariables {
 	public String toString() {
 		return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
 	}
+
 }

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariablesActiveObject.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariablesActiveObject.java
@@ -6,10 +6,12 @@ import net.java.ao.schema.Table;
 @Table("cf_config_vars")
 public interface ConfigurationVariablesActiveObject extends Entity{
 
-	public String getTokenAudience();
-	public void setTokenAudience(String tokenAudience);
+	String getTokenAudience();
+	void setTokenAudience(String tokenAudience);
 
-	public String getAuthDomain();
-	public void setAuthDomain(String authDomain);
+	String getAuthDomain();
+	void setAuthDomain(String authDomain);
 
+	String getAllowedEmailDomain();
+	void setAllowedEmailDomain(String allowedEmailDomain);
 }

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/PersistentPluginConfiguration.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/PersistentPluginConfiguration.java
@@ -1,6 +1,9 @@
 package com.cloudflare.access.atlassian.base.config;
 
 import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.cloudflare.access.atlassian.common.CertificateProvider;
 import com.cloudflare.access.atlassian.common.config.PluginConfiguration;
@@ -9,14 +12,21 @@ import com.cloudflare.access.atlassian.common.context.AuthenticationContext;
 public class PersistentPluginConfiguration implements PluginConfiguration{
 
 	private AuthenticationContext authContext;
+	private ConfigurationVariables variables;
 
 	public PersistentPluginConfiguration(ConfigurationVariables variables, CertificateProvider certificateProvider) {
 		this.authContext = new PersistentAuthenticationContext(variables, certificateProvider);
+		this.variables = variables;
 	}
 
 	@Override
 	public AuthenticationContext getAuthenticationContext() {
 		return authContext;
+	}
+
+	@Override
+	public Optional<String> getAllowedEmailDomain() {
+		return Optional.ofNullable(StringUtils.defaultIfEmpty(variables.getAllowedEmailDomain(), null));
 	}
 
 	public static final class PersistentAuthenticationContext implements AuthenticationContext{

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/impl/DefaultConfigurationService.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/impl/DefaultConfigurationService.java
@@ -49,6 +49,7 @@ public class DefaultConfigurationService implements ConfigurationService{
 
 		ao.setTokenAudience(configVariables.getTokenAudience());
 		ao.setAuthDomain(configVariables.getAuthDomain());
+		ao.setAllowedEmailDomain(configVariables.getAllowedEmailDomain());
 		ao.save();
 
 		log.info("Publishing configuration changed event...");

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/impl/DefaultConfigurationService.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/impl/DefaultConfigurationService.java
@@ -1,5 +1,7 @@
 package com.cloudflare.access.atlassian.base.config.impl;
 
+import static org.apache.commons.lang3.StringUtils.*;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -91,6 +93,17 @@ public class DefaultConfigurationService implements ConfigurationService{
 		}else {
 			return Optional.empty();
 		}
+	}
+
+	@Override
+	public boolean emailDomainRequiresAtlassianAuthentication(String email) {
+		String emailDomain = defaultString(substringAfterLast(email, "@"), "");
+		Optional<String> allowedEmailDomain = getPluginConfiguration().flatMap(cfg -> cfg.getAllowedEmailDomain());
+		if(allowedEmailDomain.isPresent()) {
+			return emailDomain.equalsIgnoreCase(allowedEmailDomain.get()) == false;
+		}
+		//by default, don't require atlassian authentication.
+		return false;
 	}
 
 	private static enum CacheKey{

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/validation/NullableDomain.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/validation/NullableDomain.java
@@ -1,0 +1,35 @@
+package com.cloudflare.access.atlassian.base.config.validation;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import org.apache.bval.extras.constraints.net.Domain;
+
+/**
+ * Validation annotation to wrap the @Domain annotation allowing nulls.
+ *
+ * The message from
+ * @author felipebn
+ *
+ */
+@Documented
+@Constraint(validatedBy = NullableDomainValidator.class)
+@Target({ FIELD, ANNOTATION_TYPE, PARAMETER })
+@Retention(RUNTIME)
+public @interface NullableDomain {
+
+	Domain domain() default @Domain();
+
+    Class<?>[] groups() default {};
+
+    String message() default "{org.apache.bval.extras.constraints.net.Domain.message}";
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/validation/NullableDomain.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/validation/NullableDomain.java
@@ -15,7 +15,9 @@ import org.apache.bval.extras.constraints.net.Domain;
 /**
  * Validation annotation to wrap the @Domain annotation allowing nulls.
  *
- * The message from
+ * The domain attribute may be overridden, but the message, group and payload should
+ * always be set using this annotation attributes.
+ *
  * @author felipebn
  *
  */
@@ -27,9 +29,10 @@ public @interface NullableDomain {
 
 	Domain domain() default @Domain();
 
-    Class<?>[] groups() default {};
+	Class<?>[] groups() default {};
 
-    String message() default "{org.apache.bval.extras.constraints.net.Domain.message}";
+	String message() default "{org.apache.bval.extras.constraints.net.Domain.message}";
 
-    Class<? extends Payload>[] payload() default {};
+	Class<? extends Payload>[] payload() default {};
+
 }

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/validation/NullableDomainValidator.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/validation/NullableDomainValidator.java
@@ -1,0 +1,24 @@
+package com.cloudflare.access.atlassian.base.config.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.apache.bval.extras.constraints.net.DomainValidator;
+import org.apache.commons.lang3.StringUtils;
+
+public class NullableDomainValidator implements ConstraintValidator<NullableDomain, String> {
+
+	private DomainValidator delegate = new DomainValidator();
+
+	@Override
+	public void initialize(NullableDomain constraintAnnotation) {
+		delegate.initialize(constraintAnnotation.domain());
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if(StringUtils.isEmpty(value)) return true;
+		return delegate.isValid(value, context);
+	}
+
+}

--- a/base-plugin/src/main/resources/pluginMessages.properties
+++ b/base-plugin/src/main/resources/pluginMessages.properties
@@ -7,5 +7,9 @@ cfaccess.config.authDomain.should.not.be.empty = Authentication Domain should no
 cfaccess.config.authDomain.should.be.valid = Authentication Domain should be a valid domain
 cfaccess.config.authDomain.description = Cloudflare Access configured authentication domain
 
+cfaccess.config.allowedEmailDomain = Allowed Email Domain
+cfaccess.config.allowedEmailDomain.should.be.valid = Allowed Email Domain should be a valid domain
+cfaccess.config.allowedEmailDomain.description = Restricts which Email Domains are allowed to skip Atlassian standard authentication. By default, all domains are allowed.
+
 cfaccess.warning.filteringDisabled.title = Authentication Filters Disabled
 cfaccess.warning.filteringDisabled.message = This application was started with 'cloudflareAccessPlugin.filters.disabled' flag set to 'true', configuration changes will only be effective after restarting this application whithout this flag. 

--- a/base-plugin/src/main/resources/pluginMessages.properties
+++ b/base-plugin/src/main/resources/pluginMessages.properties
@@ -9,7 +9,7 @@ cfaccess.config.authDomain.description = Cloudflare Access configured authentica
 
 cfaccess.config.allowedEmailDomain = Allowed Email Domain
 cfaccess.config.allowedEmailDomain.should.be.valid = Allowed Email Domain should be a valid domain
-cfaccess.config.allowedEmailDomain.description = Restricts which Email Domains are allowed to skip Atlassian standard authentication. By default, all domains are allowed.
+cfaccess.config.allowedEmailDomain.description = Emails that match this domain will authorize with their Access JWT. All other emails will be required authorize again with their Atlassian credentials.
 
 cfaccess.warning.filteringDisabled.title = Authentication Filters Disabled
 cfaccess.warning.filteringDisabled.message = This application was started with 'cloudflareAccessPlugin.filters.disabled' flag set to 'true', configuration changes will only be effective after restarting this application whithout this flag. 

--- a/base-plugin/src/main/resources/templates/config.vm
+++ b/base-plugin/src/main/resources/templates/config.vm
@@ -52,6 +52,12 @@
       </div>
       
       <div class="field-group">
+        <label for="authDomain">$i18n.getText("cfaccess.config.allowedEmailDomain")</label>
+        <input type="text" class="text long-field" id="allowedEmailDomain" name="allowedEmailDomain" value="$!{config.allowedEmailDomain}">
+        <div class="description">$i18n.getText("cfaccess.config.allowedEmailDomain.description")</div>
+      </div>
+      
+      <div class="field-group">
         <input type="submit" class="button" value="Save">
       </div>
     </form>

--- a/bitbucket-plugin/pom.xml
+++ b/bitbucket-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
     </parent>
     <artifactId>bitbucket-plugin</artifactId>
 

--- a/bitbucket-plugin/pom.xml
+++ b/bitbucket-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.1</version>
+        <version>2.10.0</version>
     </parent>
     <artifactId>bitbucket-plugin</artifactId>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.9.9</version>
+		    <version>2.9.9.3</version>
 		</dependency>
 		
 		<dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.9.1</version>
+		<version>2.10.0</version>
 	</parent>
 
 	<artifactId>common</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.9.0</version>
+		<version>2.9.1</version>
 	</parent>
 
 	<artifactId>common</artifactId>
@@ -54,7 +54,7 @@
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.9.8</version>
+		    <version>2.9.9</version>
 		</dependency>
 		
 		<dependency>

--- a/common/src/main/java/com/cloudflare/access/atlassian/common/config/PluginConfiguration.java
+++ b/common/src/main/java/com/cloudflare/access/atlassian/common/config/PluginConfiguration.java
@@ -1,9 +1,12 @@
 package com.cloudflare.access.atlassian.common.config;
 
+import java.util.Optional;
+
 import com.cloudflare.access.atlassian.common.context.AuthenticationContext;
 
 public interface PluginConfiguration {
 
 	AuthenticationContext getAuthenticationContext();
 
+	Optional<String> getAllowedEmailDomain();
 }

--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.1</version>
+        <version>2.10.0</version>
     </parent>
     <artifactId>confluence-plugin</artifactId>
     <organization>

--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
     </parent>
     <artifactId>confluence-plugin</artifactId>
     <organization>

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>jira-plugin</artifactId>

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.9.1</version>
+        <version>2.10.0</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>jira-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.cloudflare.access.atlassian</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.9.0</version>
+	<version>2.9.1</version>
 	<packaging>pom</packaging>
 
 	<name>Cloudflare Access for Atlassian</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.cloudflare.access.atlassian</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.9.1</version>
+	<version>2.10.0</version>
 	<packaging>pom</packaging>
 
 	<name>Cloudflare Access for Atlassian</name>


### PR DESCRIPTION
This pull request includes:

- Jackson databind upgrades
- Configuration update to set the allowed email domain (issue #41 )
- Request handling to redirect to Atlassian product authentication when the user's email domain is not allowed