### PR TITLE
#46 - ActiveObjects related errors when installing 2.11

### DIFF
--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/support/PluginStateService.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/support/PluginStateService.java
@@ -1,0 +1,53 @@
+package com.cloudflare.access.atlassian.base.support;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.atlassian.event.api.EventPublisher;
+import com.atlassian.plugin.event.PluginEventListener;
+import com.atlassian.plugin.event.events.PluginEnabledEvent;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+
+@Component
+public class PluginStateService implements InitializingBean, DisposableBean {
+
+	private static final Logger log = LoggerFactory.getLogger(PluginStateService.class);
+
+	private final EventPublisher eventPublisher;
+
+	private boolean ready;
+
+	@Autowired
+	public PluginStateService(@ComponentImport EventPublisher eventPublisher) {
+		Objects.requireNonNull(eventPublisher);
+		this.eventPublisher = eventPublisher;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		this.eventPublisher.register(this);
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		this.eventPublisher.unregister(this);
+	}
+
+
+	@PluginEventListener
+	public void onEvent(PluginEnabledEvent pluginEnabledEvent) {
+		log.info("Pugin enabled event received, setting READY flag!");
+		this.ready = true;
+	}
+
+	public boolean isReady() {
+		return ready;
+	}
+
+}

--- a/base-plugin/src/test/java/com/cloudflare/access/atlassian/base/auth/CloudflareAccessServiceTest.java
+++ b/base-plugin/src/test/java/com/cloudflare/access/atlassian/base/auth/CloudflareAccessServiceTest.java
@@ -1,7 +1,12 @@
 package com.cloudflare.access.atlassian.base.auth;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -23,6 +28,7 @@ import org.springframework.core.env.Environment;
 import com.atlassian.crowd.embedded.api.User;
 import com.atlassian.plugin.PluginAccessor;
 import com.cloudflare.access.atlassian.base.config.ConfigurationService;
+import com.cloudflare.access.atlassian.base.support.PluginStateService;
 import com.cloudflare.access.atlassian.base.utils.EnvironmentFlags;
 import com.cloudflare.access.atlassian.common.config.PluginConfiguration;
 import com.cloudflare.access.atlassian.common.context.AuthenticationContext;
@@ -45,6 +51,8 @@ public class CloudflareAccessServiceTest {
 	private FailedAuthenticationRequestHandler failureHandler;
 	@Mock
 	private Environment env;
+	@Mock
+	private PluginStateService pluginStateService;
 
 	private PluginConfiguration mockPluginConfiguration;
 	private TestAuthenticationContext authContext;
@@ -52,6 +60,8 @@ public class CloudflareAccessServiceTest {
 	@Before
 	public void setupDefaults() {
 		when(pluginAcessor.isPluginEnabled(anyString())).thenReturn(true);
+		when(pluginStateService.isReady()).thenReturn(true);
+
 
 		authContext = new TestAuthenticationContext();
 
@@ -60,7 +70,7 @@ public class CloudflareAccessServiceTest {
 	}
 
 	private CloudflareAccessService newCloudflareAccessServiceInstance() {
-		return new CloudflareAccessService(pluginAcessor, pluginDetails, configurationService, userService, successHandler, failureHandler, env);
+		return new CloudflareAccessService(pluginAcessor, pluginDetails, configurationService, userService, successHandler, failureHandler, env, pluginStateService);
 	}
 
 	@Test


### PR DESCRIPTION
Sometimes the plugin filter would try to access the configuration before it's fully initialized, leading to the issue.

This change adds an event listener to know when it's safe to allow the filter to be applied.

