### PR TITLE
Changes to support Confluence 7.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project impements a set of plugins for authenticating users through Cloudfl
 
 Currently supported products are:
 - JIRA
-- Confluence
+- Confluence >= 6.x
 - Bitbucket
 
 ## Installation

--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -50,13 +50,7 @@
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugin</groupId>
-            <artifactId>atlassian-spring-scanner-runtime</artifactId>
-            <version>${atlassian.spring.scanner.version}</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -69,8 +63,8 @@
             <artifactId>atlassian-template-renderer-api</artifactId>
             <version>${atlassian.templaterenderer.version}</version>
             <scope>provided</scope>
-		</dependency>
-        
+        </dependency>
+
         <!-- WIRED TEST RUNNER DEPENDENCIES -->
         <dependency>
             <groupId>com.atlassian.plugins</groupId>
@@ -136,15 +130,15 @@
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
                         <!-- Add package to export here -->
                         <Export-Package>
-                        	com.cloudflare.access.atlassian.confluence.auth.*,
+                            com.cloudflare.access.atlassian.confluence.auth.*,
                         </Export-Package>
                         <!-- Add package import here -->
                         <Import-Package>
-                        	org.springframework.osgi.*;resolution:="optional", 
-                        	org.eclipse.gemini.blueprint.*;resolution:="optional",
-                        	com.atlassian.plugin.*;, 
-                        	com.atlassian.crowd.*;,
-                        	*;resolution:="optional"
+                            org.springframework.osgi.*;resolution:="optional",
+                            org.eclipse.gemini.blueprint.*;resolution:="optional",
+                            com.atlassian.plugin.*;,
+                            com.atlassian.crowd.*;,
+                            *;resolution:="optional"
                         </Import-Package>
                         <!-- Ensure plugin is spring powered -->
                         <Spring-Context>*</Spring-Context>
@@ -164,9 +158,9 @@
                     </execution>
                 </executions>
                 <configuration>
-                	<includeExclude>
-                		-.*DefaultFailedAuthHandler.*
-                	</includeExclude>
+                    <includeExclude>
+                        -.*DefaultFailedAuthHandler.*
+                    </includeExclude>
                     <scannedDependencies>
                         <dependency>
                             <groupId>com.atlassian.plugin</groupId>
@@ -187,7 +181,7 @@
         <confluence.data.version>6.7.1</confluence.data.version>
         <amps.version>6.3.15</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <atlassian.spring.scanner.version>2.2.0</atlassian.spring.scanner.version>
         <atlassian.templaterenderer.version>2.1.0</atlassian.templaterenderer.version>
         <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml and the key to generate bundle. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>

--- a/confluence-plugin/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/confluence-plugin/src/main/resources/META-INF/spring/plugin-context.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.atlassian.com/schema/atlassian-scanner
-        http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
+        http://www.atlassian.com/schema/atlassian-scanner/2
+        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
     <atlassian-scanner:scan-indexes/>
 </beans>


### PR DESCRIPTION
As reported on #52 the Confluence plugin does not work on Confluence 7.3.x.
This is due that Confluence 7.3.x does not support atlassian-spring-scanner 1.x.

This PR updates the plugin to use atlassian-spring-scanner 2.x.

