### PR TITLE
Updating atlassian-spring-scanner to 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project impements a set of plugins for authenticating users through Cloudflare Access on Atlassian products.
 
 Currently supported products are:
-- JIRA
+- JIRA >= 7.2
 - Confluence >= 6.x
 - Bitbucket
 

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -59,14 +59,7 @@
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.atlassian.plugin</groupId>
-            <artifactId>atlassian-spring-scanner-runtime</artifactId>
-            <version>${atlassian.spring.scanner.version}</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -237,7 +230,7 @@
         <amps.version>6.3.15</amps.version>
         <netty.version>4.0.44.Final</netty.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <atlassian.spring.scanner.version>2.2.0</atlassian.spring.scanner.version>
         <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml and the key to generate bundle. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <!-- TestKit version 6.x for JIRA 6.x -->

--- a/jira-plugin/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/jira-plugin/src/main/resources/META-INF/spring/plugin-context.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.atlassian.com/schema/atlassian-scanner
-        http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
+        http://www.atlassian.com/schema/atlassian-scanner/2
+        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
     <atlassian-scanner:scan-indexes/>
 </beans>


### PR DESCRIPTION
This change will allow the plugin to working on future versions of JIRA that don't support version atlassian-spring-scanner 1.x.