### PR TITLE
Add user field matching configuration

### DIFF
--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationService.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationService.java
@@ -2,8 +2,6 @@ package com.cloudflare.access.atlassian.base.config;
 
 import java.util.Optional;
 
-import com.cloudflare.access.atlassian.common.config.PluginConfiguration;
-
 public interface ConfigurationService {
 
 	void save(ConfigurationVariables configurationVariables);

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationServlet.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationServlet.java
@@ -134,8 +134,9 @@ public class ConfigurationServlet extends HttpServlet{
 		String tokenAudience = request.getParameter("tokenAudience");
 	    String authDomain = request.getParameter("authDomain");
 	    String allowedEmailDomain = request.getParameter("allowedEmailDomain");
+	    String userMatchingAttribute = request.getParameter("userMatchingAttribute");
 
-		return new ConfigurationVariables(tokenAudience, authDomain, allowedEmailDomain);
+		return new ConfigurationVariables(tokenAudience, authDomain, allowedEmailDomain, userMatchingAttribute);
 	}
 
 	private Map<String, Object> createContext(){

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariables.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariables.java
@@ -1,9 +1,11 @@
 package com.cloudflare.access.atlassian.base.config;
 
+
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.apache.bval.extras.constraints.net.Domain;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -17,6 +19,7 @@ public class ConfigurationVariables {
 	public static final String TOKEN_AUDIENCE_SETTINGS_KEY = SETTINGS_PREFIX + "tokenAudience";
 	public static final String AUTH_DOMAIN_SETTINGS_KEY = SETTINGS_PREFIX + "authDomain";
 	public static final String ALLOWED_EMAIL_DOMAIN_SETTINGS_KEY = SETTINGS_PREFIX + "authDomain";
+	public static final String USER_MATCHING_ATTRIBUTE_SETTINGS_KEY = SETTINGS_PREFIX + "userMatchingAttribute";
 
 	@NotNull(message="cfaccess.config.tokenAudience.should.not.be.empty")
 	@Size(min=1, message="cfaccess.config.tokenAudience.should.not.be.empty")
@@ -30,11 +33,15 @@ public class ConfigurationVariables {
 	@NullableDomain(message="cfaccess.config.allowedEmailDomain.should.be.valid")
 	private String allowedEmailDomain;
 
+	@NotNull
+	private UserMatchingAttribute userMatchingAttribute;
+
 	public ConfigurationVariables(ConfigurationVariablesActiveObject activeObject) {
 		super();
 		this.tokenAudience = activeObject.getTokenAudience();
 		this.authDomain = activeObject.getAuthDomain();
 		this.allowedEmailDomain = activeObject.getAllowedEmailDomain();
+		this.userMatchingAttribute = ObjectUtils.defaultIfNull(activeObject.getUserMatchingAttribute(), UserMatchingAttribute.defaultAttribute());
 	}
 
 	public ConfigurationVariables(String tokenAudience, String authDomain, String allowedEmailDomain) {
@@ -54,6 +61,11 @@ public class ConfigurationVariables {
 
 	public String getAllowedEmailDomain() {
 		return allowedEmailDomain;
+	}
+
+	@NotNull
+	public UserMatchingAttribute getUserMatchingAttribute() {
+		return userMatchingAttribute;
 	}
 
 	@Override

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariables.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariables.java
@@ -5,6 +5,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.apache.bval.extras.constraints.net.Domain;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -33,7 +34,7 @@ public class ConfigurationVariables {
 	@NullableDomain(message="cfaccess.config.allowedEmailDomain.should.be.valid")
 	private String allowedEmailDomain;
 
-	@NotNull
+	@NotNull(message="cfaccess.config.userMatchingAttribute.should.be.valid")
 	private UserMatchingAttribute userMatchingAttribute;
 
 	public ConfigurationVariables(ConfigurationVariablesActiveObject activeObject) {
@@ -44,11 +45,12 @@ public class ConfigurationVariables {
 		this.userMatchingAttribute = ObjectUtils.defaultIfNull(activeObject.getUserMatchingAttribute(), UserMatchingAttribute.defaultAttribute());
 	}
 
-	public ConfigurationVariables(String tokenAudience, String authDomain, String allowedEmailDomain) {
+	public ConfigurationVariables(String tokenAudience, String authDomain, String allowedEmailDomain, String userMatchingAttribute) {
 		super();
 		this.tokenAudience = tokenAudience;
 		this.authDomain = authDomain;
 		this.allowedEmailDomain = allowedEmailDomain;
+		this.userMatchingAttribute = EnumUtils.isValidEnum(UserMatchingAttribute.class, userMatchingAttribute) ? UserMatchingAttribute.valueOf(userMatchingAttribute) : UserMatchingAttribute.EMAIL;
 	}
 
 	public String getTokenAudience() {

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariablesActiveObject.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/ConfigurationVariablesActiveObject.java
@@ -14,4 +14,7 @@ public interface ConfigurationVariablesActiveObject extends Entity{
 
 	String getAllowedEmailDomain();
 	void setAllowedEmailDomain(String allowedEmailDomain);
+
+	UserMatchingAttribute getUserMatchingAttribute();
+	void setUserMatchingAttribute(UserMatchingAttribute userMatchingAttribute);
 }

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/PersistentPluginConfiguration.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/PersistentPluginConfiguration.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 import com.cloudflare.access.atlassian.common.CertificateProvider;
-import com.cloudflare.access.atlassian.common.config.PluginConfiguration;
 import com.cloudflare.access.atlassian.common.context.AuthenticationContext;
 
 public class PersistentPluginConfiguration implements PluginConfiguration{
@@ -27,6 +26,11 @@ public class PersistentPluginConfiguration implements PluginConfiguration{
 	@Override
 	public Optional<String> getAllowedEmailDomain() {
 		return Optional.ofNullable(StringUtils.defaultIfEmpty(variables.getAllowedEmailDomain(), null));
+	}
+
+	@Override
+	public UserMatchingAttribute getUserMatchingAttribute() {
+		return variables.getUserMatchingAttribute();
 	}
 
 	public static final class PersistentAuthenticationContext implements AuthenticationContext{

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/PluginConfiguration.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/PluginConfiguration.java
@@ -1,4 +1,4 @@
-package com.cloudflare.access.atlassian.common.config;
+package com.cloudflare.access.atlassian.base.config;
 
 import java.util.Optional;
 
@@ -9,4 +9,6 @@ public interface PluginConfiguration {
 	AuthenticationContext getAuthenticationContext();
 
 	Optional<String> getAllowedEmailDomain();
+
+	UserMatchingAttribute getUserMatchingAttribute();
 }

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/UserMatchingAttribute.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/UserMatchingAttribute.java
@@ -1,0 +1,29 @@
+package com.cloudflare.access.atlassian.base.config;
+
+import com.atlassian.crowd.search.query.entity.restriction.Property;
+import com.atlassian.crowd.search.query.entity.restriction.constants.UserTermKeys;
+
+public enum UserMatchingAttribute {
+	EMAIL(UserTermKeys.EMAIL, "Email address"),
+	USERNAME(UserTermKeys.USERNAME, "Username");
+
+	private Property<String> userTerm;
+	private String displayName;
+
+	private UserMatchingAttribute(Property<String> userTerm, String displayName) {
+		this.userTerm = userTerm;
+		this.displayName = displayName;
+	}
+
+	public Property<String> getUserTerm() {
+		return userTerm;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	public static final UserMatchingAttribute defaultAttribute() {
+		return EMAIL;
+	}
+}

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/impl/DefaultConfigurationService.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/impl/DefaultConfigurationService.java
@@ -1,6 +1,7 @@
 package com.cloudflare.access.atlassian.base.config.impl;
 
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 
 import java.util.Map;
 import java.util.Optional;
@@ -21,8 +22,8 @@ import com.cloudflare.access.atlassian.base.config.ConfigurationService;
 import com.cloudflare.access.atlassian.base.config.ConfigurationVariables;
 import com.cloudflare.access.atlassian.base.config.ConfigurationVariablesActiveObject;
 import com.cloudflare.access.atlassian.base.config.PersistentPluginConfiguration;
+import com.cloudflare.access.atlassian.base.config.PluginConfiguration;
 import com.cloudflare.access.atlassian.common.CertificateProvider;
-import com.cloudflare.access.atlassian.common.config.PluginConfiguration;
 import com.cloudflare.access.atlassian.common.http.SimpleHttp;
 
 @Component
@@ -52,6 +53,7 @@ public class DefaultConfigurationService implements ConfigurationService{
 		ao.setTokenAudience(configVariables.getTokenAudience());
 		ao.setAuthDomain(configVariables.getAuthDomain());
 		ao.setAllowedEmailDomain(configVariables.getAllowedEmailDomain());
+		ao.setUserMatchingAttribute(configVariables.getUserMatchingAttribute());
 		ao.save();
 
 		log.info("Publishing configuration changed event...");
@@ -106,7 +108,7 @@ public class DefaultConfigurationService implements ConfigurationService{
 		return false;
 	}
 
-	private static enum CacheKey{
+	private enum CacheKey{
 		MAIN_CONFIG;
 	}
 }

--- a/base-plugin/src/main/resources/pluginMessages.properties
+++ b/base-plugin/src/main/resources/pluginMessages.properties
@@ -11,5 +11,10 @@ cfaccess.config.allowedEmailDomain = Allowed Email Domain
 cfaccess.config.allowedEmailDomain.should.be.valid = Allowed Email Domain should be a valid domain
 cfaccess.config.allowedEmailDomain.description = Emails that match this domain will authorize with their Access JWT. All other emails will be required authorize again with their Atlassian credentials.
 
+cfaccess.config.userMatchingAttribute = Match users by
+cfaccess.config.userMatchingAttribute.should.be.valid = You must select one of the available attributes
+cfaccess.config.userMatchingAttribute.description = Atlassian user attribute to match with the user email 
+
+
 cfaccess.warning.filteringDisabled.title = Authentication Filters Disabled
 cfaccess.warning.filteringDisabled.message = This application was started with 'cloudflareAccessPlugin.filters.disabled' flag set to 'true', configuration changes will only be effective after restarting this application whithout this flag. 

--- a/base-plugin/src/main/resources/templates/config.vm
+++ b/base-plugin/src/main/resources/templates/config.vm
@@ -57,6 +57,20 @@
         <div class="description">$i18n.getText("cfaccess.config.allowedEmailDomain.description")</div>
       </div>
       
+    <div class="field-group">
+        <label for="userMatchingAttribute">$i18n.getText("cfaccess.config.userMatchingAttribute")</label>
+        
+        #set($emailSelected = "#if($config.userMatchingAttribute.name() == 'EMAIL')selected#{else}#end")
+        #set($usernameSelected = "#if($config.userMatchingAttribute.name() == 'USERNAME')selected#{else}#end")
+        
+        <select id="userMatchingAttribute" name="userMatchingAttribute" class="select">
+            <option value="EMAIL" $emailSelected >Email</option>
+            <option value="USERNAME" $usernameSelected >Username</option>
+        </select>
+        
+        <div class="description">$i18n.getText("cfaccess.config.userMatchingAttribute.description")</div>
+      </div>
+      
       <div class="field-group">
         <input type="submit" class="button" value="Save">
       </div>

--- a/base-plugin/src/test/java/com/cloudflare/access/atlassian/base/auth/CloudflareAccessServiceTest.java
+++ b/base-plugin/src/test/java/com/cloudflare/access/atlassian/base/auth/CloudflareAccessServiceTest.java
@@ -28,9 +28,9 @@ import org.springframework.core.env.Environment;
 import com.atlassian.crowd.embedded.api.User;
 import com.atlassian.plugin.PluginAccessor;
 import com.cloudflare.access.atlassian.base.config.ConfigurationService;
+import com.cloudflare.access.atlassian.base.config.PluginConfiguration;
 import com.cloudflare.access.atlassian.base.support.PluginStateService;
 import com.cloudflare.access.atlassian.base.utils.EnvironmentFlags;
-import com.cloudflare.access.atlassian.common.config.PluginConfiguration;
 import com.cloudflare.access.atlassian.common.context.AuthenticationContext;
 import com.cloudflare.access.atlassian.common.exception.CloudflareAccessUnauthorizedException;
 


### PR DESCRIPTION
Configuration now allows users to select which Atlassian user attribute will be used to find a user matching the email in Access JWT.

The default is kept as before, matching by email.

Updated configuration UI:
![image](https://user-images.githubusercontent.com/209101/78176992-4b254f80-7455-11ea-9344-e8fabdd7c3e3.png)
