### PR TITLE
Improve JWT verification

### DIFF
--- a/base-plugin/pom.xml
+++ b/base-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.12.0</version>
+		<version>2.13.0</version>
 	</parent>
 	<artifactId>base-plugin</artifactId>
 

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/PersistentPluginConfiguration.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/config/PersistentPluginConfiguration.java
@@ -1,9 +1,9 @@
 package com.cloudflare.access.atlassian.base.config;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
 
 import com.cloudflare.access.atlassian.common.CertificateProvider;
 import com.cloudflare.access.atlassian.common.context.AuthenticationContext;
@@ -37,10 +37,12 @@ public class PersistentPluginConfiguration implements PluginConfiguration{
 
 		private ConfigurationVariables variables;
 		private CertificateProvider certificateProvider;
+		private String certificatesUrl;
 
 		public PersistentAuthenticationContext(ConfigurationVariables variables, CertificateProvider certificateProvider) {
 			this.variables = variables;
 			this.certificateProvider = certificateProvider;
+			this.certificatesUrl = String.format("https://%s/cdn-cgi/access/certs", variables.getAuthDomain());
 		}
 
 		@Override
@@ -54,9 +56,8 @@ public class PersistentPluginConfiguration implements PluginConfiguration{
 		}
 
 		@Override
-		public List<String> getSigningKeyAsJson() {
-			String url = String.format("https://%s/cdn-cgi/access/certs", variables.getAuthDomain());
-			return this.certificateProvider.getCerticatesAsJson(url);
+		public JsonWebKey getJwk(String kid) {
+			return certificateProvider.getJwk(certificatesUrl, kid);
 		}
 
 		@Override

--- a/bitbucket-plugin/pom.xml
+++ b/bitbucket-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.12.0</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>bitbucket-plugin</artifactId>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.12.0</version>
+		<version>2.13.0</version>
 	</parent>
 
 	<artifactId>common</artifactId>

--- a/common/src/main/java/com/cloudflare/access/atlassian/common/context/AuthenticationContext.java
+++ b/common/src/main/java/com/cloudflare/access/atlassian/common/context/AuthenticationContext.java
@@ -1,15 +1,16 @@
 package com.cloudflare.access.atlassian.common.context;
 
 import java.time.Clock;
-import java.util.List;
+
+import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
 
 public interface AuthenticationContext {
-	public String getAudience();
-	public String getIssuer();
-	public List<String> getSigningKeyAsJson();
-	public String getLogoutUrl();
+	String getAudience();
+	String getIssuer();
+	JsonWebKey getJwk(String kid);
+	String getLogoutUrl();
 
-	default public Clock getClock() {
+	default Clock getClock() {
 		return Clock.systemUTC();
 	}
 }

--- a/common/src/test/java/com/cloudflare/access/atlassian/common/CertificateProviderTest.java
+++ b/common/src/test/java/com/cloudflare/access/atlassian/common/CertificateProviderTest.java
@@ -1,17 +1,19 @@
 package com.cloudflare.access.atlassian.common;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.List;
 
+import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
 import org.junit.Test;
 
 import com.cloudflare.access.atlassian.common.http.SimpleHttp;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class CertificateProviderTest {
 
@@ -42,19 +44,67 @@ public class CertificateProviderTest {
 				"}"
 		);
 		CertificateProvider certificateProvider = new CertificateProvider(httpMock);
-		List<String> certificates = certificateProvider.getCerticatesAsJson(url);
+		JsonWebKey firstCertificate = certificateProvider.getJwk(url, "bccdf99ac336c9278e3c7ac71bebcbe467bbbfd1fb013c84c93889da077b9d79");
 
-		assertThat(certificates, hasSize(2));
-		JsonNode cert0 = new ObjectMapper().readTree(certificates.get(0));
-		assertThat(cert0.get("kid").asText(null), equalTo("bccdf99ac336c9278e3c7ac71bebcbe467bbbfd1fb013c84c93889da077b9d79"));
-		assertThat(cert0.get("alg").asText(null), equalTo("RS256"));
-		assertThat(cert0.get("n").asText(null), equalTo("x4SANlqANMzNkJfruQU8RbwZ6B_N-ed4b5-CscBHV1sIR3Fo6q-1BF7votDBIJ05q3ahKNYIqHDF7xiKhVCHxXVwYuh3HULcetylHSh-I6C_P66mLxHLLagLSvsmr6ZdCqdEsDJS33RUJtlIODt-3OBaPqyfUjy4Ql5d7LC5bfAztX3RyKwkrlT2X9o62-GmbgvJGwFrPISyWUHF9trH82oaxtN3TxZ4L3LKBkPdexIPuTJGs4wse0pMd-v7439E_Quzm-eM61eXM4IP5YEf5sjBxbGsZgqcNuEM_2S_K9AKyj0mOleSoBAfFCCkz2QZTn7jHXz2yreLbpPSXY9e3Q"));
+		assertNotNull(firstCertificate);
+		assertThat(firstCertificate.getKeyId(), equalTo("bccdf99ac336c9278e3c7ac71bebcbe467bbbfd1fb013c84c93889da077b9d79"));
+		assertThat(firstCertificate.getAlgorithm(), equalTo("RS256"));
+		assertThat(firstCertificate.getProperty("n"), equalTo("x4SANlqANMzNkJfruQU8RbwZ6B_N-ed4b5-CscBHV1sIR3Fo6q-1BF7votDBIJ05q3ahKNYIqHDF7xiKhVCHxXVwYuh3HULcetylHSh-I6C_P66mLxHLLagLSvsmr6ZdCqdEsDJS33RUJtlIODt-3OBaPqyfUjy4Ql5d7LC5bfAztX3RyKwkrlT2X9o62-GmbgvJGwFrPISyWUHF9trH82oaxtN3TxZ4L3LKBkPdexIPuTJGs4wse0pMd-v7439E_Quzm-eM61eXM4IP5YEf5sjBxbGsZgqcNuEM_2S_K9AKyj0mOleSoBAfFCCkz2QZTn7jHXz2yreLbpPSXY9e3Q"));
 
-		JsonNode cert1 = new ObjectMapper().readTree(certificates.get(1));
-		assertThat(cert1.get("kid").asText(null), equalTo("d018809a98fba8261a7e732c53603dac25d25d3ea73b219e2193a04977f3ff55"));
-		assertThat(cert1.get("alg").asText(null), equalTo("RS256"));
-		assertThat(cert1.get("n").asText(null), equalTo("uEiwOJS9VDh_k2u21TI8zBUuDCY9rDjc9btqJ-assMhJv-0O17kw4nV4kBivswDfw8z6XMeU_lurbgc1_cWQdpQk03CPSLzk3NJLDNmfnBGQApHXxAyl8ba_-0SaAuEchwdcWD9bfuV-Dru2Qkg5hfVon7_aTOWsYF2L3wXOWRxUfL35TvsN6MQYBrdZ4IjaQcl2LDY3ugSV1LK8IpAR6JCFuNzro_CRuJR8BvtZArUC6k-rIzl9yQOHuvkoYHaXtMyFyrojCAZGG-NqREl0MfpuZQ2vgFUPRtxAHTb8CETqkXgKCMJHumetvcDnrIKwqyimJYfFbHbIYzmzxYKeYQ"));
+		JsonWebKey secondCertificate = certificateProvider.getJwk(url, "d018809a98fba8261a7e732c53603dac25d25d3ea73b219e2193a04977f3ff55");
+		assertNotNull(secondCertificate);
+		assertThat(secondCertificate.getKeyId(), equalTo("d018809a98fba8261a7e732c53603dac25d25d3ea73b219e2193a04977f3ff55"));
+		assertThat(secondCertificate.getAlgorithm(), equalTo("RS256"));
+		assertThat(secondCertificate.getProperty("n"), equalTo("uEiwOJS9VDh_k2u21TI8zBUuDCY9rDjc9btqJ-assMhJv-0O17kw4nV4kBivswDfw8z6XMeU_lurbgc1_cWQdpQk03CPSLzk3NJLDNmfnBGQApHXxAyl8ba_-0SaAuEchwdcWD9bfuV-Dru2Qkg5hfVon7_aTOWsYF2L3wXOWRxUfL35TvsN6MQYBrdZ4IjaQcl2LDY3ugSV1LK8IpAR6JCFuNzro_CRuJR8BvtZArUC6k-rIzl9yQOHuvkoYHaXtMyFyrojCAZGG-NqREl0MfpuZQ2vgFUPRtxAHTb8CETqkXgKCMJHumetvcDnrIKwqyimJYfFbHbIYzmzxYKeYQ"));
+
+		verify(httpMock, times(1)).get(url);
 	}
 
 
+	@Test
+	public void testCacheInvalidationWhenKidIsUnknown() {
+		final String url = "https://cfaplugin.oraculo.io/cdn-cgi/access/certs";
+		SimpleHttp httpMock = mock(SimpleHttp.class);
+		when(httpMock.get(url)).thenReturn(
+				"{\n" +
+				"  \"keys\": [\n" +
+				"    {\n" +
+				"      \"kid\": \"bccdf99ac336c9278e3c7ac71bebcbe467bbbfd1fb013c84c93889da077b9d79\",\n" +
+				"      \"kty\": \"RSA\",\n" +
+				"      \"alg\": \"RS256\",\n" +
+				"      \"use\": \"sig\",\n" +
+				"      \"e\": \"AQAB\",\n" +
+				"      \"n\": \"x4SANlqANMzNkJfruQU8RbwZ6B_N-ed4b5-CscBHV1sIR3Fo6q-1BF7votDBIJ05q3ahKNYIqHDF7xiKhVCHxXVwYuh3HULcetylHSh-I6C_P66mLxHLLagLSvsmr6ZdCqdEsDJS33RUJtlIODt-3OBaPqyfUjy4Ql5d7LC5bfAztX3RyKwkrlT2X9o62-GmbgvJGwFrPISyWUHF9trH82oaxtN3TxZ4L3LKBkPdexIPuTJGs4wse0pMd-v7439E_Quzm-eM61eXM4IP5YEf5sjBxbGsZgqcNuEM_2S_K9AKyj0mOleSoBAfFCCkz2QZTn7jHXz2yreLbpPSXY9e3Q\"\n" +
+				"    }\n" +
+				"  ]\n" +
+				"}"
+		).thenReturn(
+				"{\n" +
+				"  \"keys\": [\n" +
+				"    {\n" +
+				"      \"kid\": \"d018809a98fba8261a7e732c53603dac25d25d3ea73b219e2193a04977f3ff55\",\n" +
+				"      \"kty\": \"RSA\",\n" +
+				"      \"alg\": \"RS256\",\n" +
+				"      \"use\": \"sig\",\n" +
+				"      \"e\": \"AQAB\",\n" +
+				"      \"n\": \"uEiwOJS9VDh_k2u21TI8zBUuDCY9rDjc9btqJ-assMhJv-0O17kw4nV4kBivswDfw8z6XMeU_lurbgc1_cWQdpQk03CPSLzk3NJLDNmfnBGQApHXxAyl8ba_-0SaAuEchwdcWD9bfuV-Dru2Qkg5hfVon7_aTOWsYF2L3wXOWRxUfL35TvsN6MQYBrdZ4IjaQcl2LDY3ugSV1LK8IpAR6JCFuNzro_CRuJR8BvtZArUC6k-rIzl9yQOHuvkoYHaXtMyFyrojCAZGG-NqREl0MfpuZQ2vgFUPRtxAHTb8CETqkXgKCMJHumetvcDnrIKwqyimJYfFbHbIYzmzxYKeYQ\"\n" +
+				"    }\n" +
+				"  ]\n" +
+				"}"
+		);
+		CertificateProvider certificateProvider = new CertificateProvider(httpMock);
+
+		//First get returns the JWK
+		JsonWebKey firstCertificate = certificateProvider.getJwk(url, "bccdf99ac336c9278e3c7ac71bebcbe467bbbfd1fb013c84c93889da077b9d79");
+		assertNotNull(firstCertificate);
+		assertThat(firstCertificate.getKeyId(), equalTo("bccdf99ac336c9278e3c7ac71bebcbe467bbbfd1fb013c84c93889da077b9d79"));
+
+
+		//Then try to get a JWK with an unknown JWK
+		JsonWebKey secondCertificate = certificateProvider.getJwk(url, "d018809a98fba8261a7e732c53603dac25d25d3ea73b219e2193a04977f3ff55");
+		assertNotNull(secondCertificate);
+		assertThat(secondCertificate.getKeyId(), equalTo("d018809a98fba8261a7e732c53603dac25d25d3ea73b219e2193a04977f3ff55"));
+
+		verify(httpMock, times(2)).get(url);
+	}
 }

--- a/common/src/test/java/com/cloudflare/access/atlassian/common/TestVerificationContext.java
+++ b/common/src/test/java/com/cloudflare/access/atlassian/common/TestVerificationContext.java
@@ -5,16 +5,21 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
+import org.apache.cxf.rs.security.jose.jwk.JsonWebKeys;
+import org.apache.cxf.rs.security.jose.jwk.JwkUtils;
 
 import com.cloudflare.access.atlassian.common.context.AuthenticationContext;
 
 class TestVerificationContext implements AuthenticationContext{
 
+	private final JsonWebKeys jwkSet;
 	private String audience;
 	private String issuer;
-	private List<String> jwkJsons;
 	private Clock clock;
 
 	public TestVerificationContext() {
@@ -23,8 +28,8 @@ class TestVerificationContext implements AuthenticationContext{
 		this.issuer = "https://cfaplugin.cloudflareaccess.com";
 		LocalDateTime nineOClock = LocalDateTime.of(2018, Month.MAY, 10, 20, 00);
 		this.clock = Clock.fixed(nineOClock.toInstant(ZoneOffset.UTC), ZoneOffset.UTC);
-		this.jwkJsons = new ArrayList<>();
-		this.jwkJsons.add("{\n" +
+		List<String> jwkJsons = new ArrayList<>();
+		jwkJsons.add("{\n" +
 				"			\"kid\": \"bccdf99ac336c9278e3c7ac71bebcbe467bbbfd1fb013c84c93889da077b9d79\",\n" +
 				"			\"kty\": \"RSA\",\n" +
 				"			\"alg\": \"RS256\",\n" +
@@ -32,7 +37,7 @@ class TestVerificationContext implements AuthenticationContext{
 				"			\"e\": \"AQAB\",\n" +
 				"			\"n\": \"x4SANlqANMzNkJfruQU8RbwZ6B_N-ed4b5-CscBHV1sIR3Fo6q-1BF7votDBIJ05q3ahKNYIqHDF7xiKhVCHxXVwYuh3HULcetylHSh-I6C_P66mLxHLLagLSvsmr6ZdCqdEsDJS33RUJtlIODt-3OBaPqyfUjy4Ql5d7LC5bfAztX3RyKwkrlT2X9o62-GmbgvJGwFrPISyWUHF9trH82oaxtN3TxZ4L3LKBkPdexIPuTJGs4wse0pMd-v7439E_Quzm-eM61eXM4IP5YEf5sjBxbGsZgqcNuEM_2S_K9AKyj0mOleSoBAfFCCkz2QZTn7jHXz2yreLbpPSXY9e3Q\"\n" +
 				"		}");
-		this.jwkJsons.add("{\n" +
+		jwkJsons.add("{\n" +
 				"			\"kid\": \"facb70eaf23a06573eb449601e345b8d2de562fb943de556d2cfda34870f7629\",\n" +
 				"			\"kty\": \"RSA\",\n" +
 				"			\"alg\": \"RS256\",\n" +
@@ -40,22 +45,24 @@ class TestVerificationContext implements AuthenticationContext{
 				"			\"e\": \"AQAB\",\n" +
 				"			\"n\": \"tFw6PCssph26IC8gkdGCYmRDJWdZnp3tiWqkcJ_ILgRr-FdwITaIroCNWXoB7DoqttjXUSwDgE9emtMk6wo_Lt3jAwmjrkH6Fo663GfcZy0BHf9s8Y2F2cXtgsWu7oKeeXJuh_7fGsmJ44gTKAEa_w7cx0nmRjPlecDWThQMFsejttMuavXfLbtnNfSiJ5VMHuZHfqHW4jCCUYFcrOzaqIWG0covhyrdbIF8oip0wpWtyET7jbuxhASNsJQfBQET-Gkdzd8wvHE4qOdUwlrtgJuLgW2S7MBgBtBmPG3n9cQ4asJRUUE-CXw6PjYbVCyVJ7ifjoo_knWEZpQXhl1rAQ\"\n" +
 				"		}");
-		this.jwkJsons.add("{\n" + 
-				"			\"kid\": \"6593d9acf92b87faca750a78f7b308a844a57ae51c25ed7322fe06d6d8a6b9b0\",\n" + 
-				"			\"kty\": \"RSA\",\n" + 
-				"			\"alg\": \"RS256\",\n" + 
-				"			\"use\": \"sig\",\n" + 
-				"			\"e\": \"AQAB\",\n" + 
-				"			\"n\": \"z5kk3ksqN2_3HRc1I0Wqfmpyii-2GeZiczd1BdUaZCm59HuRpTzFy44sP0Vo1ND8oJA33CnotkSX5TWZpZNfeD3B0HX3GRqYTQxu08le3gL91GlHgJ_yMyNl2tLCTUqDDhFs1YGM0PJCNgsasQHNkaY3bSSkcUlYyoPWWEyPPmU5eOhUbcjRb9sGJV03HyA-93GXEZIVrX4aIdPu7dteMuAb7YiMJ6nnldouydIqmlK4N6iIvPOXQoBuMOIARSnjy6AVYh8pCc9yJPwMn_SxK27HEmfFDxx8Ed_oYWm3-kONhVoTTGd5p9fDX4i2_D2mWMvJ_EhTRlWIA-Qc962O3w\"\n" + 
+		jwkJsons.add("{\n" +
+				"			\"kid\": \"6593d9acf92b87faca750a78f7b308a844a57ae51c25ed7322fe06d6d8a6b9b0\",\n" +
+				"			\"kty\": \"RSA\",\n" +
+				"			\"alg\": \"RS256\",\n" +
+				"			\"use\": \"sig\",\n" +
+				"			\"e\": \"AQAB\",\n" +
+				"			\"n\": \"z5kk3ksqN2_3HRc1I0Wqfmpyii-2GeZiczd1BdUaZCm59HuRpTzFy44sP0Vo1ND8oJA33CnotkSX5TWZpZNfeD3B0HX3GRqYTQxu08le3gL91GlHgJ_yMyNl2tLCTUqDDhFs1YGM0PJCNgsasQHNkaY3bSSkcUlYyoPWWEyPPmU5eOhUbcjRb9sGJV03HyA-93GXEZIVrX4aIdPu7dteMuAb7YiMJ6nnldouydIqmlK4N6iIvPOXQoBuMOIARSnjy6AVYh8pCc9yJPwMn_SxK27HEmfFDxx8Ed_oYWm3-kONhVoTTGd5p9fDX4i2_D2mWMvJ_EhTRlWIA-Qc962O3w\"\n" +
 				"		}");
-		this.jwkJsons.add("{\n" + 
-				"			\"kid\": \"7b956c1e7ab1ea3a3b4649adbe6ac2cd546e9d373d3b942cfc0c71b4c58f9457\",\n" + 
-				"			\"kty\": \"RSA\",\n" + 
-				"			\"alg\": \"RS256\",\n" + 
-				"			\"use\": \"sig\",\n" + 
-				"			\"e\": \"AQAB\",\n" + 
-				"			\"n\": \"1FsOGfFsdlWJwQlWO5gM_RfzO3EsZOCDPCUR0ltc3f4z89mQEljuMkEgsIQ-0GdZluuo7ucp_CilqOeFOck6QjjNWPAzwkpD1nbvfboBZ2RwHlWlLrY4cubCv63cK1447Zwf_KobylRXpV0rDWw0NUPKHK0YO4rD5eikr2DXwbNIMFmXNxcXxhtAYVgjgNjkkc4hZosvM4KofrTviUQtCwIy2agwpe5PUF1gq7P-jnrhyPFhiV2PW8a820re7Bfg5YoGyUEwwrO4NAjfKb6zRexol4TJAWwSD4kYTc93AVh-Sw1ESbWeNAlLemM3iHhOLhyB0F-J9lfIdE9cMIB7jw\"\n" + 
+		jwkJsons.add("{\n" +
+				"			\"kid\": \"7b956c1e7ab1ea3a3b4649adbe6ac2cd546e9d373d3b942cfc0c71b4c58f9457\",\n" +
+				"			\"kty\": \"RSA\",\n" +
+				"			\"alg\": \"RS256\",\n" +
+				"			\"use\": \"sig\",\n" +
+				"			\"e\": \"AQAB\",\n" +
+				"			\"n\": \"1FsOGfFsdlWJwQlWO5gM_RfzO3EsZOCDPCUR0ltc3f4z89mQEljuMkEgsIQ-0GdZluuo7ucp_CilqOeFOck6QjjNWPAzwkpD1nbvfboBZ2RwHlWlLrY4cubCv63cK1447Zwf_KobylRXpV0rDWw0NUPKHK0YO4rD5eikr2DXwbNIMFmXNxcXxhtAYVgjgNjkkc4hZosvM4KofrTviUQtCwIy2agwpe5PUF1gq7P-jnrhyPFhiV2PW8a820re7Bfg5YoGyUEwwrO4NAjfKb6zRexol4TJAWwSD4kYTc93AVh-Sw1ESbWeNAlLemM3iHhOLhyB0F-J9lfIdE9cMIB7jw\"\n" +
 				"		}");
+		jwkSet = new JsonWebKeys();
+		jwkSet.setKeys(jwkJsons.stream().map(JwkUtils::readJwkKey).collect(Collectors.toList()));
 	}
 
 	TestVerificationContext withAudience(String audience) {
@@ -74,7 +81,7 @@ class TestVerificationContext implements AuthenticationContext{
 	}
 
 	TestVerificationContext withJwkJson(String jwkJson) {
-		this.jwkJsons = Collections.singletonList(jwkJson);
+		jwkSet.setKeys(Stream.of(jwkJson).map(JwkUtils::readJwkKey).collect(Collectors.toList()));
 		return this;
 	}
 
@@ -89,8 +96,8 @@ class TestVerificationContext implements AuthenticationContext{
 	}
 
 	@Override
-	public List<String> getSigningKeyAsJson() {
-		return this.jwkJsons;
+	public JsonWebKey getJwk(String kid) {
+		return jwkSet.getKey(kid);
 	}
 
 	@Override

--- a/common/src/test/java/com/cloudflare/access/atlassian/common/TokenVerifierTest.java
+++ b/common/src/test/java/com/cloudflare/access/atlassian/common/TokenVerifierTest.java
@@ -24,6 +24,7 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 public class TokenVerifierTest {
 
 	private static String expectedFailureMessage = "Invalid or expired token. Please logout and try again or proceed with your Atlassian credentials.";
+	private static String expectedVerificationFailureMessage = "Invalid token, unable to parse/verify. Please logout and try again or proceed with your Atlassian credentials.";
 	private static String tokenForFirstSigningKey;
 	private static String tokenForFirstSigningKeyWithEscapedUrl;
 	private static String tokenForSecondSigningKey;
@@ -39,13 +40,13 @@ public class TokenVerifierTest {
 				"eyJhdWQiOlsiYjI2NTg0NmM4NWU3MGFhNDA2NTVhNzZlNTM4NThkZjZjNzljYjJkMDQ1M2ZlZmY0OTVmM2M1Yjc5NWZiNGQ1ZSJdLCJlbWFpbCI6ImZlbGlwZS5uYXNjaW1lbnRvMUBnbWFpbC5jb20iLCJleHAiOjE1MjYwNzA2NDAsImlhdCI6MTUyNTk4NDI0MSwiaXNzIjoiaHR0cHM6Ly9jZmFwbHVnaW4uY2xvdWRmbGFyZWFjY2Vzcy5jb20iLCJub25jZSI6ImRhMWUxOTRkNDI4YTgwZDNhY2IwNzcxOWI4ZDYzZjdlODViZjZlMmVlOWNmZmZiMGQ0Y2FiYWE4YmE0Mzg2Y2QiLCJzdWIiOiI0YjgyYjM4YS05MjM2LTQ5M2QtODc1Mi01ODBhZDAwMGVhM2UifQ",
 				"wrRj3wDqmBIN8f4JX-ioM43mxggGp1BF7QnlF8pvs2bMiscJyZD61GHHBZj9rfnWBTVJ0jEzjk7ZlGmgG8ndKHFzzvqxbtaCalOEnG7rIgZ3ch_JOimABQCguAItM5WbQbDpePD431VKdCqtK4u88QaX-h-TJUqG2DeYA1ZXyi-OevIkYu7vaKjIei0eUa1qr5wtKBYFbjNDVCGfXasiYt8Z75hnzO1jhoNFOowLLECUKtE4-1Uazc3M6kSqKLqARe0aWwm1TWTZlE0Qtbdrup5wulFqHb_zdWvtlJKmPJF3W7d6NmgI17pmk8bW_KYqbkQNwyD_pAnVDXWZBKv3BQ"
 			}).collect(Collectors.joining("."));
-		
+
 		tokenForFirstSigningKeyWithEscapedUrl = Arrays.stream(new String[]{
 				"eyJraWQiOiI2NTkzZDlhY2Y5MmI4N2ZhY2E3NTBhNzhmN2IzMDhhODQ0YTU3YWU1MWMyNWVkNzMyMmZlMDZkNmQ4YTZiOWIwIiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ",
 				"eyJhdWQiOiJiMjY1ODQ2Yzg1ZTcwYWE0MDY1NWE3NmU1Mzg1OGRmNmM3OWNiMmQwNDUzZmVmZjQ5NWYzYzViNzk1ZmI0ZDVlIiwiZXhwIjoxNTQ5NDk1Njk0LCJpc3MiOiJodHRwczpcL1wvY2ZhcGx1Z2luLmNsb3VkZmxhcmVhY2Nlc3MuY29tIiwiaWF0IjoxNTQ5NDA5Mjk0LCJzdWIiOiIifQ",
 				"ougV1tAGM2eX_nQCYxA5bmheokL0cSM_4eKHg2xXx7HFam1RX8_5AucpHFt3BvHSmjgw31RadCRNO1kTvNF4ZaZ4Lo8_DIuwVKBssGQ5pCRGTO99a8NaBBMoOn5c-tOXqaKPwcvtZDql_-QtsI15SvuBaAUA3sfFnpm8BGsQLPYkmgt2ZHJclJzUT_rUO5WSEKGOoQLOc0WmYCBik6B2peILFru4hAgLkzNA5DW_Imj5cTvVgg0f7o4gQyuF-bGdtrXq0g84Ikowe2cttlvzGpWp0AfMQRwREiRo4Po2oIJeUG-sTepNdZ8MmmiROprnm0feTVgWmgqY83J6yr0CYA"
 			}).collect(Collectors.joining("."));
-		
+
 		tokenForSecondSigningKey = Arrays.stream(new String[]{
 				"eyJhbGciOiJSUzI1NiIsImtpZCI6ImZhY2I3MGVhZjIzYTA2NTczZWI0NDk2MDFlMzQ1YjhkMmRlNTYyZmI5NDNkZTU1NmQyY2ZkYTM0ODcwZjc2MjkiLCJ0eXAiOiJKV1QifQ",
 				"eyJhdWQiOlsiYjI2NTg0NmM4NWU3MGFhNDA2NTVhNzZlNTM4NThkZjZjNzljYjJkMDQ1M2ZlZmY0OTVmM2M1Yjc5NWZiNGQ1ZSJdLCJlbWFpbCI6ImZlbGlwZS5uYXNjaW1lbnRvMUBnbWFpbC5jb20iLCJleHAiOjE1MzY4ODAyMjEsImlhdCI6MTUzNjc5MzgyMiwiaXNzIjoiaHR0cHM6Ly9jZmFwbHVnaW4uY2xvdWRmbGFyZWFjY2Vzcy5jb20iLCJub25jZSI6Ijk4MmNmNjAxNjVjMjU3MjFkNDVjOTMyMjBlOTUxMjMwMjM0NzA5ODZkYjVmMTgzZjAwMGQ5MDQ3ODNlZDFmNWYiLCJzdWIiOiI0YjgyYjM4YS05MjM2LTQ5M2QtODc1Mi01ODBhZDAwMGVhM2UifQ",
@@ -86,7 +87,7 @@ public class TokenVerifierTest {
 	@Test
 	@DataProvider(value={ "null", "", "badvalue", "eyJhbGciOiJSUzI1NiIsImtpZCI6ImJjY2RmOTlhYzMzNmM5Mjc4ZTNjN2FjNzFiZWJjYmU0NjdiYmJmZDFmYjAxM2M4NGM5Mzg4OWRhMDc3YjlkNzkiLCJ0eXAiOiJKV1QifQ" }, convertNulls=true)
 	public void shouldNotAcceptMalformedTokens(String badToken) {
-		expectedException.expect(new ExceptionMatcher (InvalidJWTException.class, expectedFailureMessage));
+		expectedException.expect(new ExceptionMatcher (InvalidJWTException.class, expectedVerificationFailureMessage));
 
 		TokenVerifier tokenVerifier = new TokenVerifier(new TestVerificationContext());
 		tokenVerifier.validate(badToken);
@@ -94,7 +95,7 @@ public class TokenVerifierTest {
 
 	@Test
 	public void shouldNotAcceptBadSigning() {
-		expectedException.expect(new ExceptionMatcher (InvalidJWTException.class, expectedFailureMessage));
+		expectedException.expect(new ExceptionMatcher (InvalidJWTException.class, expectedVerificationFailureMessage));
 		String badJwkJson = "{\n" +
 				"			\"kid\": \"bccdf99ac336c9278e3c7ac71bebcbe467bbbfd1fb013c84c93889da077b9d79\",\n" +
 				"			\"kty\": \"RSA\",\n" +
@@ -112,7 +113,7 @@ public class TokenVerifierTest {
 		TokenVerifier tokenVerifier = new TokenVerifier(new TestVerificationContext());
 		tokenVerifier.validate(tokenForFirstSigningKey);
 	}
-	
+
 	@Test
 	public void shouldAcceptValidTokenWithEscapedIssuer() {
 		TokenVerifier tokenVerifier = new TokenVerifier(new TestVerificationContext());

--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.12.0</version>
+        <version>2.13.0</version>
     </parent>
     <artifactId>confluence-plugin</artifactId>
     <organization>

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.12.0</version>
+        <version>2.13.0</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>jira-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.cloudflare.access.atlassian</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.12.0</version>
+	<version>2.13.0</version>
 	<packaging>pom</packaging>
 
 	<name>Cloudflare Access for Atlassian</name>


### PR DESCRIPTION
Before when verifying the JWT it would:

- parse one key from the JWK set
- try to verify the JWT
- try next if fails

This was inneficient as the parse for the same key yields always the
same result and that the JWT indicates which is the JWK key id to be
used for verification.

Now it will cache the JWK set already parsed, invalidating when a new
key id or URL is requested and will use the key id from the JWT to
lookup the right parsed JWK.

On a micro benchmarks this increases the troughput from ~9300/ops to
~19500/ops which might help the issue reported @ GH #58.