### PR TITLE
Bump jackson databind to latest patch

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.9.10.3</version>
+		    <version>2.9.10.5</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
Bumps to 2.9.10.5, dependabot suggested 2.10.x on #59 but that minor version
is build with JDK > 8 which breaks the OSGi packaging.