### PR TITLE
Fix instance healthcheck and stuck threads

### DIFF
--- a/base-plugin/pom.xml
+++ b/base-plugin/pom.xml
@@ -148,7 +148,12 @@
             <artifactId>hsqldb</artifactId>
             <version>1.8.0.10</version>
             <scope>test</scope>
-        </dependency>          
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+        </dependency>
 	</dependencies>
 
 	<properties>

--- a/base-plugin/pom.xml
+++ b/base-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.15.1</version>
+		<version>2.15.2</version>
 	</parent>
 	<artifactId>base-plugin</artifactId>
 

--- a/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/support/GithubVersionProvider.java
+++ b/base-plugin/src/main/java/com/cloudflare/access/atlassian/base/support/GithubVersionProvider.java
@@ -31,7 +31,7 @@ public class GithubVersionProvider implements RemoteVersionProvider{
 
 	GithubVersionProvider(String latestReleaseCheckUrl){
 		this.latestReleaseCheckUrl = latestReleaseCheckUrl;
-		this.fetchResult = Suppliers.memoizeWithExpiration(this::fetchLatestReleasedVersion, 5, TimeUnit.MINUTES);
+		this.fetchResult = Suppliers.memoizeWithExpiration(this::fetchLatestReleasedVersion, 1, TimeUnit.HOURS);
 	}
 
 	@Override

--- a/base-plugin/src/test/java/com/cloudflare/access/atlassian/base/config/impl/DefaultConfigurationServiceTest.java
+++ b/base-plugin/src/test/java/com/cloudflare/access/atlassian/base/config/impl/DefaultConfigurationServiceTest.java
@@ -1,14 +1,18 @@
 package com.cloudflare.access.atlassian.base.config.impl;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertNotNull;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,17 +27,18 @@ import com.cloudflare.access.atlassian.base.config.TokenAudienceActiveObject;
 import com.google.common.collect.Sets;
 
 import net.java.ao.EntityManager;
+import net.java.ao.test.jdbc.NonTransactional;
 import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
 
 @RunWith(ActiveObjectsJUnitRunner.class)
 public class DefaultConfigurationServiceTest {
 
 	private EntityManager entityManager;
-	
+
 	private DefaultConfigurationService configService;
-	
+
 	private EventPublisher eventPublisherMock;
-	
+
 	@Before
 	public void setup() {
 		assertNotNull(entityManager);
@@ -44,22 +49,24 @@ public class DefaultConfigurationServiceTest {
 			TokenAudienceActiveObject.class,
 			ConfigurationVariablesActiveObject.class
 		);
-		
+
 		configService = new DefaultConfigurationService(ao, eventPublisherMock);
 	}
-	
+
 	@Test
+	@NonTransactional
 	public void saveShouldPersistSingleAudience() throws SQLException {
 		configService.save(new ConfigurationVariables(Sets.newHashSet("the_audience"), "domain", "testdomain.com", "someattribute"));
-		
+
 		ConfigurationVariablesActiveObject[] configs = entityManager.find(ConfigurationVariablesActiveObject.class);
-		
+
 		assertThat(configs.length, is(1));
 		assertThat(configs[0].getTokenAudiences().length, is(1));
 		assertThat(configs[0].getTokenAudiences()[0].getValue(), is("the_audience"));
 	}
-	
+
 	@Test
+	@NonTransactional
 	public void saveShouldPersistMultipleAudiences() throws SQLException {
 		configService.save(new ConfigurationVariables(
 				Sets.newHashSet("the_audience_01", "the_audience_02", "the_audience_03"),
@@ -78,13 +85,31 @@ public class DefaultConfigurationServiceTest {
 	}
 
 	@Test
+	@NonTransactional
 	public void saveShouldRemovePreviousAudiences() throws SQLException {
 		configService.save(new ConfigurationVariables(Sets.newHashSet("the_audience_01"), "domain", "testdomain.com", "someattribute"));
 		configService.save(new ConfigurationVariables(Sets.newHashSet("the_audience_02"), "domain", "testdomain.com", "someattribute"));
 		ConfigurationVariablesActiveObject[] configs = entityManager.find(ConfigurationVariablesActiveObject.class);
-		
+
 		assertThat(configs.length, is(1));
 		assertThat(configs[0].getTokenAudiences().length, is(1));
 		assertThat(configs[0].getTokenAudiences()[0].getValue(), is("the_audience_02"));
+	}
+
+	@Test
+	@NonTransactional
+	public void findFirstShouldPreloadRelations() throws SQLException {
+		configService.save(new ConfigurationVariables(Sets.newHashSet("the_audience_01"), "domain", "testdomain.com", "someattribute"));
+
+		ConfigurationVariablesActiveObject config = configService.findFirst().get();
+
+		// Adds a listener to catch queries executed after findFirst returned.
+		List<String> queriesAfterFindFirst = new ArrayList<>();
+		entityManager.getProvider().addSqlListener(sql -> queriesAfterFindFirst.add(sql));
+
+		// Assert the relation was loaded correctly, if preload was not done
+		// this will trigger a query.
+		assertThat(Arrays.stream(config.getTokenAudiences()).map(aud -> aud.getValue()).collect(Collectors.toSet()), is(Sets.newHashSet("the_audience_01")));
+		assertThat(queriesAfterFindFirst, is(empty()));
 	}
 }

--- a/base-plugin/src/test/java/com/cloudflare/access/atlassian/base/support/GithubVersionProviderTest.java
+++ b/base-plugin/src/test/java/com/cloudflare/access/atlassian/base/support/GithubVersionProviderTest.java
@@ -1,20 +1,114 @@
 package com.cloudflare.access.atlassian.base.support;
 
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 
 public class GithubVersionProviderTest {
 
+	private static final long DEFAULT_READ_TIMEOUT = 10L;
+	private SlowHttpServer testServer;
+
+	@Before
+	public void setup() throws IOException {
+		this.testServer = new SlowHttpServer();
+	}
+
+	@After
+	public void teardown() {
+		this.testServer.shutdown();
+	}
+
 	@Test
-	@Ignore("Ignored to build")
 	public void testThatCanRetrieveLatestReleaseInfo() {
 		String latestReleaseVersion = new GithubVersionProvider().getLatestReleaseVersion();
-		System.out.println("Retrieved latest version: " + latestReleaseVersion);
 		assertTrue(StringUtils.isNotBlank(latestReleaseVersion));
 		assertTrue(latestReleaseVersion.matches("[0-9]+\\.[0-9]+\\.[0-9]+$"));
 	}
 
+	@Test(timeout = 30 * 1000)
+	public void testThatItDoesNotHangLongerThanDefaultTimeoutReturningEmpty() {
+		testServer.makeServerHang();
+		Instant start = Instant.now();
+		String latestReleaseVersion = new GithubVersionProvider(testServer.getUrl("/slow")).getLatestReleaseVersion();
+		long hangDuration = Duration.between(start, Instant.now()).toSeconds();
+		testServer.releaseServerWork();
+
+		assertThat(hangDuration, is(greaterThanOrEqualTo(DEFAULT_READ_TIMEOUT)));
+		// check that it didn't took too much longer than the read timeout to complete
+		assertThat(hangDuration, is(lessThanOrEqualTo(DEFAULT_READ_TIMEOUT + 2)));
+		assertTrue(StringUtils.isBlank(latestReleaseVersion));
+	}
+
+
+	/**
+	 * This is a test HTTP server that will provide
+	 * a way to hang a request for some time to validate
+	 * the timeout configuration.
+	 */
+	static class SlowHttpServer{
+		private static final Logger log = LoggerFactory.getLogger(SlowHttpServer.class);
+		private final HttpServer server;
+
+		/**
+		 * Used to control the server hanging
+		 */
+		private ReentrantLock lock = new ReentrantLock();
+
+		SlowHttpServer() throws IOException{
+			server = HttpServer.create(new InetSocketAddress(0), 0);
+			log.info("Started test http server at port {}", server.getAddress().getPort());
+			server.createContext("/slow", this::handleGetWithDelay);
+			server.setExecutor(null);
+			server.start();
+		}
+
+		void handleGetWithDelay(HttpExchange he) throws IOException {
+			lock.lock();
+			lock.unlock();
+			he.sendResponseHeaders(200, 0);
+			OutputStream os = he.getResponseBody();
+			os.close();
+		}
+
+		void shutdown(){
+			releaseServerWork();
+			log.info("Shutdown test http server...");
+			server.stop(0);
+		}
+
+		void makeServerHang() {
+			lock.lock();
+		}
+
+		void releaseServerWork() {
+			if(lock.isLocked()) {
+				lock.unlock();
+			}
+		}
+
+		String getUrl(String path) {
+			return String.format("http://localhost:%d%s", server.getAddress().getPort(), path);
+		}
+	}
 }

--- a/bitbucket-plugin/pom.xml
+++ b/bitbucket-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.15.1</version>
+        <version>2.15.2</version>
     </parent>
     <artifactId>bitbucket-plugin</artifactId>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.15.1</version>
+		<version>2.15.2</version>
 	</parent>
 
 	<artifactId>common</artifactId>

--- a/common/src/main/java/com/cloudflare/access/atlassian/common/http/SimpleHttp.java
+++ b/common/src/main/java/com/cloudflare/access/atlassian/common/http/SimpleHttp.java
@@ -1,9 +1,10 @@
 package com.cloudflare.access.atlassian.common.http;
 
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
 import com.cloudflare.access.atlassian.common.exception.HttpRequestException;
@@ -11,7 +12,7 @@ import com.cloudflare.access.atlassian.common.exception.HttpRequestException;
 public class SimpleHttp {
 
 	public String get(String url) {
-		try(CloseableHttpClient http = HttpClients.createMinimal()){
+		try(CloseableHttpClient http = httpClientWithTimeout()){
 			CloseableHttpResponse response = http.execute(new HttpGet(url));
 			return EntityUtils.toString(response.getEntity());
 		} catch (Exception e) {
@@ -20,5 +21,16 @@ public class SimpleHttp {
 		}
 	}
 
+	public static CloseableHttpClient httpClientWithTimeout() {
+		return HttpClientBuilder.create()
+				.setDefaultRequestConfig(defaultRequestConfigBuilder().build())
+				.build();
+	}
 
+	public static RequestConfig.Builder defaultRequestConfigBuilder() {
+		return RequestConfig.custom()
+				  .setConnectTimeout(10 * 1000)
+				  .setConnectionRequestTimeout(10 * 1000)
+				  .setSocketTimeout(10 * 1000);
+	}
 }

--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.15.1</version>
+        <version>2.15.2</version>
     </parent>
     <artifactId>confluence-plugin</artifactId>
     <organization>

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.15.1</version>
+        <version>2.15.2</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>jira-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.cloudflare.access.atlassian</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.15.1</version>
+	<version>2.15.2</version>
 	<packaging>pom</packaging>
 
 	<name>Cloudflare Access for Atlassian</name>


### PR DESCRIPTION
- Fixes healtcheck errors where a Hibernate session is not bound to the thread, error log message:

```
2021-12-27 15:48:54,086 ERROR [http-nio-8090-exec-1] [[Standalone].[localhost].[/].[status-servlet]] log Servlet.service() for servlet [status-servlet] in context with path [] threw exception
java.lang.IllegalStateException: No Hibernate Session bound to thread, and configuration does not allow creation of non-transactional one here
        at org.springframework.orm.hibernate.SessionFactoryUtils.getSession(SessionFactoryUtils.java:316)
        at org.springframework.orm.hibernate.SessionFactoryUtils.getSession(SessionFactoryUtils.java:194)
        at com.atlassian.hibernate.SpringPluginHibernateSessionFactory.getSession(SpringPluginHibernateSessionFactory.java:23)
        at sun.reflect.GeneratedMethodAccessor281.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.atlassian.plugin.util.ContextClassLoaderSettingInvocationHandler.invoke(ContextClassLoaderSettingInvocationHandler.java:26)
        at com.sun.proxy.$Proxy291.getSession(Unknown Source)
        at sun.reflect.GeneratedMethodAccessor281.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333)
        ....
        at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
        at com.sun.proxy.$Proxy2745.find(Unknown Source)
        at com.cloudflare.access.atlassian.base.config.impl.DefaultConfigurationService.findFirst(DefaultConfigurationService.java:111)
        at com.cloudflare.access.atlassian.base.config.impl.DefaultConfigurationService.lambda$loadConfigurationVariables$6(DefaultConfigurationService.java:102)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
        at com.cloudflare.access.atlassian.base.config.impl.DefaultConfigurationService.loadConfigurationVariables(DefaultConfigurationService.java:101)
        at com.cloudflare.access.atlassian.base.config.impl.DefaultConfigurationService.getPluginConfiguration(DefaultConfigurationService.java:118)
        at com.cloudflare.access.atlassian.base.auth.CloudflareAccessService.isPluginConfigured(CloudflareAccessService.java:191)
        at com.cloudflare.access.atlassian.base.auth.CloudflareAccessService.isRequestFilteringDisabled(CloudflareAccessService.java:161)
        at com.cloudflare.access.atlassian.base.auth.CloudflareAccessService.processAuthRequest(CloudflareAccessService.java:78)
        at com.cloudflare.access.atlassian.confluence.auth.AuthenticationFilter.doFilter(AuthenticationFilter.java:46)
        at com.atlassian.plugin.servlet.filter.DelegatingPluginFilter.doFilter(DelegatingPluginFilter.java:64)

```

- Fixes missing timeout configurations for HTTP request that could hang threads indefinitely, error log message:

```
27-Dec-2021 15:38:10.949 WARNING [Catalina-utility-3] org.apache.catalina.valves.StuckThreadDetectionValve.notifyStuckThreadDetected Thread [http-nio-8090-exec-58] (id=[90539]) has been active for [60,404] milliseconds (since [12/27/21 3:37 PM]) to serve the same request for [https://confluenceserver.com/rest/cloudflare/1.0/pluginUpdateAvailability/check.json?_=1640619430465] and may be stuck (configured threshold for this StuckThreadDetectionValve is [60] seconds). There is/are [48] thread(s) in total that are monitored by this Valve and may be stuck.

```