### PR TITLE
Support multiple audiences in JWT & automate publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,31 @@ jobs:
         run: ./.github/workflows/scripts/setup_atlas.sh
       - name: Run tests
         run: atlas-mvn --batch-mode clean test
+      - name: Set version to PR reference
+        run: atlas-mvn --batch-mode versions:set -DnewVersion=PR-${{ github.event.pull_request.number }}
+      - name: Package preview Jars
+        run: atlas-mvn --batch-mode package -Dmaven.test.skip=true
+      - name: "Push artifact: Bitbucket Plugin PR-${{ github.event.pull_request.number }}"
+        uses: actions/upload-artifact@v4
+        with:
+          name: Bitbucket Plugin PR-${{ github.event.pull_request.number }}
+          path: "./bitbucket-plugin/target/*.jar"
+          compression-level: 0
+          overwrite: true
+          retention-days: 7
+      - name: "Push artifact: Confluence Plugin PR-${{ github.event.pull_request.number }}"
+        uses: actions/upload-artifact@v4
+        with:
+          name: Confluence Plugin PR-${{ github.event.pull_request.number }}
+          path: "./confluence-plugin/target/*.jar"
+          compression-level: 0
+          overwrite: true
+          retention-days: 7
+      - name: "Push artifact: JIRA Plugin PR-${{ github.event.pull_request.number }}"
+        uses: actions/upload-artifact@v4
+        with:
+          name: JIRA Plugin PR-${{ github.event.pull_request.number }}
+          path: "./jira-plugin/target/*.jar"
+          compression-level: 0
+          overwrite: true
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,15 @@
 name: CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+# Using semantic release it will package the plugin jars
+# using the next semantic version inferred from commits between
+# the latest tag and the HEAD of the branch.
+#
+# The generate JAR files are going to be published in Github
+# Releases page together with the changelog.
+#
+
+name: Release
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: maven
+      - name: Set up Atlassian SDK
+        run: ./.github/workflows/scripts/setup_atlas.sh
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/exec
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ local.properties
 .classpath
 .project
 
+# Intellij
+.idea
+
 # Maven
 target/
 *.xml.versionsBackup

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,24 @@
+{
+    "branches": [
+        "master",
+        "setup-semantic-release-action"
+    ],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        ["@semantic-release/exec", {
+          "prepareCmd": "atlas-mvn --batch-mode versions:set -DnewVersion=${nextRelease.version}",
+          "publishCmd": "./atlas-package.sh"
+        }],
+        [
+          "@semantic-release/github",
+          {
+            "assets": [
+              { "path": "bitbucket-plugin/target/*.jar", "label": "Cloudlare Access for Bitbucket ${nextRelease.version}" },
+              { "path": "confluence-plugin/target/*.jar", "label": "Cloudlare Access for Confluence ${nextRelease.version}" },
+              { "path": "jira-plugin/target/*.jar", "label": "Cloudlare Access for JIRA ${nextRelease.version}" },
+            ]
+          }
+        ]
+    ]
+}

--- a/atlas-package.sh
+++ b/atlas-package.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+# This packages the plugins using atlas-mvn and removes the generate packaged test jars
+# that are not used and shouldn't appear in releases.
+
+atlas-mvn --batch-mode package
+find ./ -type f -wholename '*target/*tests.jar' -print -exec rm {} \;

--- a/base-plugin/pom.xml
+++ b/base-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.15.2</version>
+		<version>SEM_VER</version>
 	</parent>
 	<artifactId>base-plugin</artifactId>
 

--- a/bitbucket-plugin/pom.xml
+++ b/bitbucket-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.15.2</version>
+        <version>SEM_VER</version>
     </parent>
     <artifactId>bitbucket-plugin</artifactId>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.cloudflare.access.atlassian</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.15.2</version>
+		<version>SEM_VER</version>
 	</parent>
 
 	<artifactId>common</artifactId>

--- a/common/src/main/java/com/cloudflare/access/atlassian/common/TokenVerifier.java
+++ b/common/src/main/java/com/cloudflare/access/atlassian/common/TokenVerifier.java
@@ -1,8 +1,10 @@
 package com.cloudflare.access.atlassian.common;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Objects;
 
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
 import org.apache.cxf.rs.security.jose.jws.JwsSignatureVerifier;
@@ -59,9 +61,10 @@ public class TokenVerifier {
 		}
 
 		ClaimsVerifier validateAudience() {
-			if(context.getAudiences().contains(claims.getAudience()) == false) {
-				log.debug("Invalid audience, expecting one of '{}' but received '{}'", context.getAudiences(), claims.getAudience());
-				throw new InvalidJWTException("JWT Audience does not match expected audience.");
+			final boolean hasMatchingAudience = claims.getAudiences().stream().anyMatch(aud -> context.getAudiences().contains(aud));
+			if(!hasMatchingAudience) {
+				log.debug("Invalid audiences, expecting one of '{}' but there is no intersection with JWT audiences '{}'", context.getAudiences(), claims.getAudiences());
+				throw new InvalidJWTException("None of JWT Audiences matches any of the configured expected audiences.");
 			}
 			return this;
 		}

--- a/common/src/test/java/com/cloudflare/access/atlassian/common/TestVerificationContext.java
+++ b/common/src/test/java/com/cloudflare/access/atlassian/common/TestVerificationContext.java
@@ -71,6 +71,14 @@ class TestVerificationContext implements AuthenticationContext{
 				"           \"e\": \"AQAB\",\n" +
 				"           \"n\": \"huLKORZdrfihcfFPe2zeR2ToexvJKXnxX_Ynz2AA5tiDzQzFjjcYfkmt0s4b9yLXuw-LGeo7mH5sJeWeEITW_bUhaMUdHPmbGI5ouNilgy73pocQvicIY8JNLKplm5tWFt_zu3k3D2YuULsN7AkaePyYvWswCFiA7RlT6GznaxY9BjIsfaMaCGMLb8M5IWf5pKCLJflQXCEdeoHxIH9YNXZ2ifucLqZnv_my1twzyi-QHF0u5B74IpTYBHNqlzE2A-_JvzVYs4S_xqd6_YGE4tZ0OCMhjKSdVZ1xxFyHW3rYZpTsKxB20elKWIzErxx3h31Eb7NlPXgPyc34VLeqtw\"\n" +
 				"       }");
+		jwkJsons.add("{\n" +
+				"    \"kty\": \"RSA\",\n" +
+				"    \"e\": \"AQAB\",\n" +
+				"    \"use\": \"sig\",\n" +
+				"    \"kid\": \"LclHlXOdxeA7idWcI6JRWaGuSKg=\",\n" +
+				"    \"alg\": \"RS256\",\n" +
+				"    \"n\": \"kNRbOFoHAmxbkFdD3EtLrB8RxE0M4ooABZgZQ4FuJ5izsVy9o1v3eWFimkog8P4pylQMlb1zN0A_TM6KY6l0zEzb1xUaWyu-K04ntJO4HwDdjTZT4Wwu9hIm8__2X7jlMATpzSSmEZZochutHQtvM8-3au8AsS0sbxAclin6EF90DneRen1YJExlsDO2XjcacoirV3yIkNqJWUO-FSvOWGVe2wCYhupdA91A1cXfBiqZyJKm8u86y4K29lu3EnAhV19XPfrIPJId-2bL8NV8gjMHsfLkoIVn8uhK4Npa5Wm17YLdVTu-BHjzwzWlP0QVX1dVybedQ7JeumisBC02VQ\"\n" +
+				"}");
 		jwkSet = new JsonWebKeys();
 		jwkSet.setKeys(jwkJsons.stream().map(JwkUtils::readJwkKey).collect(Collectors.toList()));
 	}

--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.15.2</version>
+        <version>SEM_VER</version>
     </parent>
     <artifactId>confluence-plugin</artifactId>
     <organization>

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.cloudflare.access.atlassian</groupId>
-        <version>2.15.2</version>
+        <version>SEM_VER</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>jira-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.cloudflare.access.atlassian</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.15.2</version>
+	<version>SEM_VER</version>
 	<packaging>pom</packaging>
 
 	<name>Cloudflare Access for Atlassian</name>


### PR DESCRIPTION
This changes introduces the follow feature:
- proper verification of Token audiences when CF Access JWT has more than one audience

and the following project improvements:
- adding plugin packaging for preview in pull requests, publishing as Github Actions Artifacts
- adding semantic release when merging changes to `master` branch

## Multiple audiences support

The plugin so far handled when the configuration had multiple audiences set but it was not expecting that the inbound CF Access JWT could have multiple audiences set.
The change now checks that the intersection of the config and the JWT has at least one match.

The scenario this happens is when Access is configured using wildcard URLs.

## Project improvements

Having the plugin packages generate as part of the PR build will allow for easy testing of the changes in a product instance.
The same way automating the release creation in Github will allow to simplify the work to publish the plugin.