### PR TITLE
fix: fix typo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   semantic-release:
-    runs-on: ubuntu-lates
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK and atlas


### PR DESCRIPTION
The latest change in the release workflow introduced a typo causing the workflow to not run and a release not being automatically published.